### PR TITLE
Fix TypeError: can't compare offset-naive and offset-aware datetimes

### DIFF
--- a/custom_components/schedule_state/sensor.py
+++ b/custom_components/schedule_state/sensor.py
@@ -406,7 +406,7 @@ class ScheduleSensorData:
         now = dt.as_local(dt_now())
         nu = time(now.hour, now.minute)
 
-        self.overrides = [o for o in self.overrides if o["expires"] > now]
+        self.overrides = [o for o in self.overrides if dt.as_local(o["expires"]) > now]
         for o in self.overrides:
             _LOGGER.debug(
                 f"{self.name}: override = {o['start']} - {o['end']} == {o['state']} [expires {o['expires']}]"


### PR DESCRIPTION
When trying to override the schedule I was getting the following error.

```
2022-04-10 03:13:46 ERROR (MainThread) [homeassistant.helpers.entity] Update for sensor.home_state fails
Traceback (most recent call last):
  File "/srv/homeassistant/lib/python3.9/site-packages/homeassistant/helpers/entity.py", line 514, in async_update_ha_state
    await self.async_device_update()
  File "/srv/homeassistant/lib/python3.9/site-packages/homeassistant/helpers/entity.py", line 742, in async_device_update
    raise exc
  File "/home/homeassistant/.homeassistant/custom_components/schedule_state/sensor.py", line 217, in async_update
    await self.data.update()
  File "/home/homeassistant/.homeassistant/custom_components/schedule_state/sensor.py", line 409, in update
    self.overrides = [o for o in self.overrides if o["expires"] > now]
  File "/home/homeassistant/.homeassistant/custom_components/schedule_state/sensor.py", line 409, in <listcomp>
    self.overrides = [o for o in self.overrides if o["expires"] > now]
TypeError: can't compare offset-naive and offset-aware datetimes
```

This is because now is a local time and `o["expires"]` is `naive` time.  See [this SO answer for more context](https://stackoverflow.com/a/15307743/24108).

Bringing `o["expires"]` into the local time fixes this error.

Running with this change gets a big 
![Works on My Machine](https://blog.codinghorror.com/content/images/uploads/2007/03/6a0120a85dcdae970b0128776ff992970c-pi.png)