### PR TITLE
Correct set_override parameter. 

### DIFF
--- a/custom_components/schedule_state/services.yaml
+++ b/custom_components/schedule_state/services.yaml
@@ -59,9 +59,9 @@ set_override:
       example: mdi:calendar-star
       selector:
         icon:
-    extended_attributes:
-      name: Extended Attributes
-      description: Extended Attributes
+    extra_attributes:
+      name: Extra Attributes
+      description: Extra Attributes
       required: false
       selector:
         object:


### PR DESCRIPTION
Fixes and closes issue #72 

Renames the parameter extended_attributes to extra_attributes within the services.yaml file. 