### PR TITLE
Update issue template with correct version information

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -16,7 +16,7 @@ Issues not containing the minimum requirements will be closed:
 
 ## Version of the schedule_state component
 <!-- If you are not using the newest version, download and try that before opening an issue
-If you are unsure about the version check the const.py file.
+If you are unsure about the version check the manifest.json file.
 -->
 
 ## Configuration


### PR DESCRIPTION
Subject says it all - I was looking for the version in `const.py` but it's in `manifest.json` nowadays

Not sure why it marks line 42 as changed, didn't touch it 🤷🏻 