### PR TITLE
Fix month condition filtering in schedule sensor

### DIFF
--- a/custom_components/schedule_state/sensor.py
+++ b/custom_components/schedule_state/sensor.py
@@ -933,7 +933,9 @@ class ScheduleSensorData:
         months = event.get("months", None) or event.get("month", None)
         if months is not None:
             month_condition = {"condition": "time", "month": months}
-            conditions.append(month_condition)
+            # Only add if not already present
+            if month_condition not in conditions:
+                conditions.append(month_condition)
 
         # Filter by weekday
         weekdays = self._get_weekdays_from_condition(conditions)

--- a/custom_components/schedule_state/sensor.py
+++ b/custom_components/schedule_state/sensor.py
@@ -1130,7 +1130,7 @@ class ScheduleSensorData:
                 # Filter time conditions with months
                 if (
                     serializable_cond.get("condition") == "time"
-                    and "month" in serializable_cond
+                    and ("month" in serializable_cond or "weekday" in serializable_cond)
                 ):
                     clean_conditions.append(serializable_cond)
                 # elif (


### PR DESCRIPTION
Should fix, this kind of generated attr 
```
condition_text: >-
          Days: Mon, Tue, Wed, Thu, Fri, Sun AND Month: 11, 12, 1, 2, 3 AND
          Month: 11, 12, 1, 2, 3 AND Month: 11, 12, 1, 2, 3 AND Month: 11, 12,
          1, 2, 3 AND Month: 11, 12, 1, 2, 3 AND Month: 11, 12, 1, 2, 3 AND
          Month: 11, 12, 1, 2, 3
```